### PR TITLE
Provide an example of using extras_require.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,14 @@ setup(
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
     install_requires=['peppercorn'],
 
+    # List additional groups of dependencies here (e.g. development dependencies).
+    # You can install these using the following syntax, for example:
+    # $ pip install -e .[dev,test]
+    extras_require = {
+        'dev': ['check-manifest'],
+        'test': ['coverage'],
+    },
+
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.


### PR DESCRIPTION
I included two keys ("dev" and "test") partly so people don't have to look up the syntax of using a comma (`"[dev,test]"`). 
