### PR TITLE
Fix URL pointing to discussion about single sourcing the version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
-    # http://packaging.python.org/en/latest/tutorial.html#version
+    # https://packaging.python.org/en/latest/development.html#single-sourcing-the-version
     version='1.2.0',
 
     description='A sample Python project',


### PR DESCRIPTION
Noticed that the version url was outdated, here is the update :-)
