### PR TITLE
update link explaining install_requires vs requirements.txt in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
-    # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
+    # https://python-packaging-user-guide.readthedocs.org/en/latest/requirements.html#install-requires-vs-requirements-files
     install_requires=['peppercorn'],
 
     # List additional groups of dependencies here (e.g. development dependencies).

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
-    # https://python-packaging-user-guide.readthedocs.org/en/latest/requirements.html#install-requires-vs-requirements-files
+    # https://packaging.python.org/en/latest/requirements.html
     install_requires=['peppercorn'],
 
     # List additional groups of dependencies here (e.g. development dependencies).


### PR DESCRIPTION
Old link is 404'ing, new URL is linked to from https://python-packaging-user-guide.readthedocs.org/en/latest/distributing.html#install-requires