### PR TITLE
have the tests we're including actually run and pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# general things to ignore
 build/
 dist/
 *.egg-info/
@@ -6,3 +7,7 @@ dist/
 __pycache__/
 *.so
 *~
+
+# due to using tox and pytest
+.tox
+.cache

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# the inclusion of the tests module is not meant to offer best practices for
+# testing in general, but rather to support the `find_packages` example in
+# setup.py that excludes installing the "tests" package

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,7 +1,7 @@
-import unittest
+# the inclusion of the tests module is not meant to offer best practices for
+# testing in general, but rather to support the `find_packages` example in
+# setup.py that excludes installing the "tests" package
 
 
-class TestSimple(unittest.TestCase):
-
-    def test_failure(self):
-        self.assertTrue(False)
+def test_success():
+    assert True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
-# this file is *not* meant to cover or endorse the use of tox or
-# cover testing as a whole,
+# this file is *not* meant to cover or endorse the use of tox or pytest or
+# testing in general,
 #
 #  It's meant to show the use of:
 #

--- a/tox.ini
+++ b/tox.ini
@@ -23,12 +23,13 @@ deps =
     check-manifest
     {py27,py33,py34}: readme
     flake8
+    pytest
 commands =
     check-manifest --ignore tox.ini,tests*
     # py26 doesn't have "setup.py check"
     {py27,py33,py34}: python setup.py check -m -r -s
     flake8 .
-
+    py.test tests
 [flake8]
 exclude = .tox,*.egg,build,data
 select = E,W,F


### PR DESCRIPTION
- have the tests we're including actually run and pass
- clarify why we're including the tests
- use pytest (not `python setup.py test`), so we don't have to add "test_suite" to setup.py (and then have to explain it).  although the latest setuptools fixes this, its likely to come up for people who don't have the latest version.