### PR TITLE
Stop suggesting python 3.2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
Pip, virtualenv, Jinja have stopped supporting 3.2

In particular it's lack of `u''` syntax makes it harder to write cross-python code.

I think it's roughly time that we don't automatically include it here as well.

If anyone disagrees, please speak now, etc etc :)