### PR TITLE
Add README.rst to source package, via MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
+# Include the README.rst file, as setup.py needs it to work
+include README.rst
+
 # Include the license file
 include LICENSE.txt
 


### PR DESCRIPTION
If README.rst is not present in the source package, then executing setup.py from said source package
will raise an exception near the top when trying to read in the contents of README.rst.
