### PR TITLE
Add comment about where to get SPDX License identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author='The Python Packaging Authority',
     author_email='pypa-dev@googlegroups.com',
 
-    # Choose your license
+    # Choose your license : https://spdx.org/licenses/
     license='MIT',
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Currently the `setup.py` file says to choose a license but doesn't give a hint as to what type of value should go in the `license` argument. 

This patch adds to the comment a link to the [Software Package Data Exchange](https://spdx.org/) [license list](https://spdx.org/licenses/) which is where the `license` values are standardized.
