### PR TITLE
Disable flake8 tests in py26 and py33

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ commands =
     check-manifest --ignore tox.ini,tests*
     # py26 doesn't have "setup.py check"
     {py27,py33,py34}: python setup.py check -m -r -s
-    flake8 .
+    # flake8 no longer supports py26 or py33
+    {py27,py34}: flake8 .
     py.test tests
 [flake8]
 exclude = .tox,*.egg,build,data


### PR DESCRIPTION
Disable flake8 tests in py26 and py33 as [they're no longer supported by flake8](http://flake8.pycqa.org/en/3.0.2/release-notes/3.0.0.html) and are causing builds to fail ([Example](https://travis-ci.org/pypa/sampleproject/jobs/156633743))
