### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@
 language: python
 
 env:
-  - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py33
   - TOXENV=py34

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,3 @@ include LICENSE.txt
 
 # Include the data files
 recursive-include data *
-
-# If using Python 2.6 or less, then have to include package data, even though
-# it's already declared in setup.py
-# include sample/*.dat

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -11,23 +11,21 @@
 #  and also to help confirm pull requests to this project.
 
 [tox]
-envlist = py{26,27,33,34}
+envlist = py{27,33,34}
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py33: python3.3
     py34: python3.4
 deps =
     check-manifest
-    {py27,py33,py34}: readme_renderer
+    readme_renderer
     flake8
     pytest
 commands =
     check-manifest --ignore tox.ini,tests*
-    # py26 doesn't have "setup.py check"
-    {py27,py33,py34}: python setup.py check -m -r -s
+    python setup.py check -m -r -s
     flake8 .
     py.test tests
 [flake8]


### PR DESCRIPTION
As mentioned in #48, `flake8` no longer supports Python 2.6.

There's already a lot of "conditionals" regarding 2.6 in this project -- let's just simplify and drop Python 2.6 support entirely instead.

Closes #48.
