### PR TITLE
Fix name of markup language

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,8 @@ recommendations for version control, documentation, or testing.
 
 This is the README file for the project.
 
-The file should use UTF-8 encoding and be written using ReStructured Text. It
+The file should use UTF-8 encoding and be written using `reStructuredText
+<http://docutils.sourceforge.net/rst.html>`_. It
 will be used to generate the project webpage on PyPI and will be displayed as
 the project homepage on common code-hosting services, and should be written for
 that purpose.


### PR DESCRIPTION
<http://docutils.sourceforge.net/rst.html> says:

> "reStructuredText" is **ONE** word, *not two*!