### PR TITLE
Store config in setup.cfg and update setuptools configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,84 @@
+[metadata]
+name = sample
+description = "A sample Python project"
+long_description = file: README.rst
+# Versions should comply with PEP440.  For a discussion on single-sourcing
+# the version across setup.py and the project code, see
+# https://packaging.python.org/en/latest/single_source_version.html
+version = 1.2.0
+# Author details
+author = The Python Packaging Authority
+author_email = pypa-dev@googlegroups.com
+# The project's main homepage.
+url = https://github.com/pypa/sampleproject
+# Choose your license
+license = MIT
+# What does your project relate to?
+keywords = sample, setuptools, development
+# See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+# How mature is this project? Common values are
+#   3 - Alpha
+#   4 - Beta
+#   5 - Production/Stable
+# Indicate who your project is intended for
+# Pick your license as you wish (should match "license" above)
+# Specify the Python versions you support here. In particular, ensure
+# that you indicate whether you support Python 2, Python 3 or both.
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    Topic :: Software Development :: Build Tools
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+
+[options]
+# You can just specify the packages manually here if your project is
+# simple. Or you can use find.
+packages = find:
+# Alternatively, if you want to distribute just a my_module.py, uncomment
+# this:
+#   py_modules=["my_module"],
+
+# List run-time dependencies here.  These will be installed by pip when
+# your project is installed. For an analysis of "install_requires" vs pip's
+# requirements files see:
+# https://packaging.python.org/en/latest/requirements.html
+install_requires = 
+    peppercorn
+
+[options.extras_require]
+# List additional groups of dependencies here (e.g. development
+# dependencies). You can install these using the following syntax,
+# for example:
+# $ pip install -e .[dev,test]
+dev =
+    check-manifest
+test = 
+    coverage
+
+[options.entry_points]
+# To provide executable scripts, use entry points in preference to the
+# "scripts" keyword. Entry points provide cross-platform support and allow
+# pip to create the appropriate form of executable for the target platform.
+console_scripts = 
+    sample = sample:main
+
+[options.package_data]
+sample = package_data.dat
+
+[options.packages.find]
+# Exclude specific packages
+exclude =
+    contrib
+    docs
+    tests
+
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python
 # 3. If at all possible, it is good practice to do this. If you cannot, you

--- a/setup.py
+++ b/setup.py
@@ -6,108 +6,13 @@ https://github.com/pypa/sampleproject
 """
 
 # Always prefer setuptools over distutils
-from setuptools import setup, find_packages
-# To use a consistent encoding
-from codecs import open
-from os import path
+from setuptools import setup
 
-here = path.abspath(path.dirname(__file__))
-
-# Get the long description from the README file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
 
 setup(
-    name='sample',
-
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.0',
-
-    description='A sample Python project',
-    long_description=long_description,
-
-    # The project's main homepage.
-    url='https://github.com/pypa/sampleproject',
-
-    # Author details
-    author='The Python Packaging Authority',
-    author_email='pypa-dev@googlegroups.com',
-
-    # Choose your license
-    license='MIT',
-
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
-        'Development Status :: 3 - Alpha',
-
-        # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-
-        # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: MIT License',
-
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-    ],
-
-    # What does your project relate to?
-    keywords='sample setuptools development',
-
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-
-    # Alternatively, if you want to distribute just a my_module.py, uncomment
-    # this:
-    #   py_modules=["my_module"],
-
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['peppercorn'],
-
-    # List additional groups of dependencies here (e.g. development
-    # dependencies). You can install these using the following syntax,
-    # for example:
-    # $ pip install -e .[dev,test]
-    extras_require={
-        'dev': ['check-manifest'],
-        'test': ['coverage'],
-    },
-
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
-    package_data={
-        'sample': ['package_data.dat'],
-    },
-
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
     data_files=[('my_data', ['data/data_file'])],
-
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # pip to create the appropriate form of executable for the target platform.
-    entry_points={
-        'console_scripts': [
-            'sample=sample:main',
-        ],
-    },
 )


### PR DESCRIPTION
### Overview
Move setup configuration to setup.cfg insteadof setup.py.

### Features
- Using setup.cfg for configure setuptools
- Sample module retrieve version from package informations or fron config file