### PR TITLE
Added license field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,9 @@ setup(
     # This should be a valid email address corresponding to the author listed
     # above.
     author_email='pypa-dev@googlegroups.com',  # Optional
+    
+    # This is the license of your project.
+    license='MIT',
 
     # Classifiers help users find your project by categorizing it.
     #

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,6 @@ setup(
     # above.
     author_email='pypa-dev@googlegroups.com',  # Optional
 
-    # This is the license of your project.
-    license='MIT',
-
     # Classifiers help users find your project by categorizing it.
     #
     # For a list of valid classifiers, see
@@ -89,7 +86,7 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
 
-        # Pick your license as you wish (should match "license" above)
+        # Pick your license as you wish
         'License :: OSI Approved :: MIT License',
 
         # Specify the Python versions you support here. In particular, ensure

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     # This should be a valid email address corresponding to the author listed
     # above.
     author_email='pypa-dev@googlegroups.com',  # Optional
-    
+
     # This is the license of your project.
     license='MIT',
 


### PR DESCRIPTION
The license field is referred to in the classifiers section, but wasn't specified anywhere in the example. This commit adds the license field to `setup()`.