### PR TITLE
Include LICENSE.txt in wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[metadata]
+# This includes the license file in the wheel.
+license_file = LICENSE.txt
+
 [bdist_wheel]
 # This flag says to generate wheels that support both Python 2 and Python
 # 3. If your code will not run unchanged on both Python 2 and 3, you will


### PR DESCRIPTION
Initially, I thought a file with the name `LICENSE.txt` would be included by default.

Before:
```shell
$ python setup.py bdist_wheel
...
$ python setup.py bdist_wheel
adding 'sample\__init__.py'
adding 'sample\package_data.dat'
adding 'sampleproject-1.2.0.data\data\my_data\data_file'
adding 'sampleproject-1.2.0.dist-info\DESCRIPTION.rst'
adding 'sampleproject-1.2.0.dist-info\entry_points.txt'
adding 'sampleproject-1.2.0.dist-info\metadata.json'
adding 'sampleproject-1.2.0.dist-info\top_level.txt'
adding 'sampleproject-1.2.0.dist-info\WHEEL'
adding 'sampleproject-1.2.0.dist-info\METADATA'
adding 'sampleproject-1.2.0.dist-info\RECORD'
```

After:
```shell
$ python setup.py bdist_wheel
...
adding 'sample\__init__.py'
adding 'sample\package_data.dat'
adding 'sampleproject-1.2.0.data\data\my_data\data_file'
adding 'sampleproject-1.2.0.dist-info\DESCRIPTION.rst'
adding 'sampleproject-1.2.0.dist-info\LICENSE.txt'
adding 'sampleproject-1.2.0.dist-info\entry_points.txt'
adding 'sampleproject-1.2.0.dist-info\metadata.json'
adding 'sampleproject-1.2.0.dist-info\top_level.txt'
adding 'sampleproject-1.2.0.dist-info\WHEEL'
adding 'sampleproject-1.2.0.dist-info\METADATA'
adding 'sampleproject-1.2.0.dist-info\RECORD'
```