### PR TITLE
Add and document the `project_urls` field.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,4 +165,16 @@ setup(
             'sample=sample:main',
         ],
     },
+
+    # List additional URLs that are relevant to your project as a dict.
+    #
+    # This field corresponds to the "Project-URL" metadata fields:
+    # https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use
+    #
+    # Examples listed include a pattern for specifying where the package
+    # maintainers would like thanks given or funding support.
+    project_urls={  # Optional
+        'funding': 'https://donate.pypi.org',
+        'thanks': 'http://saythanks.io/to/example'
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -171,10 +171,14 @@ setup(
     # This field corresponds to the "Project-URL" metadata fields:
     # https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use
     #
-    # Examples listed include a pattern for specifying where the package
-    # maintainers would like thanks given or funding support.
+    # Examples listed include a pattern for specifying where the package tracks
+    # issues, where the source is hosted, where to say thanks to the package 
+    # maintainers, and where to support the project financially. The key is
+    # what's used to render the link text on PyPI.
     project_urls={  # Optional
-        'funding': 'https://donate.pypi.org',
-        'thanks': 'http://saythanks.io/to/example'
+        'Bug Reports': 'https://github.com/pypa/sampleproject/issues',
+        'Funding': 'https://donate.pypi.org',
+        'Say Thanks!': 'http://saythanks.io/to/example',
+        'Source': 'https://github.com/pypa/sampleproject/',
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,7 @@ setup(
     # https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use
     #
     # Examples listed include a pattern for specifying where the package tracks
-    # issues, where the source is hosted, where to say thanks to the package 
+    # issues, where the source is hosted, where to say thanks to the package
     # maintainers, and where to support the project financially. The key is
     # what's used to render the link text on PyPI.
     project_urls={  # Optional


### PR DESCRIPTION
This field corresponds to
https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use
and better documentation in the sampleproject will hopefully encourage use.

This PR comes by way of https://github.com/pypa/setuptools/issues/1276.