### PR TITLE
Fix check command in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     pytest
 commands =
     check-manifest --ignore tox.ini,tests*
-    python setup.py check -m -r -s
+    python setup.py check -m -s
     flake8 .
     py.test tests
 [flake8]


### PR DESCRIPTION
There is no need to use the `-r` (`--restructuredtext`) flag with `python setup.py check` anymore, as the description is now Markdown.