### PR TITLE
More information about the 'universal' flag.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,5 +6,8 @@ license_file = LICENSE.txt
 # This flag says to generate wheels that support both Python 2 and Python
 # 3. If your code will not run unchanged on both Python 2 and 3, you will
 # need to generate separate wheels for each Python version that you
-# support.
+# support. Setting the value of 'universal' to anything other than '1',
+# 'true' or 'yes' (case insensitive) or removing this line will prevent
+# bdist_wheel from trying to make a universal wheel. For more see:
+# https://packaging.python.org/tutorials/distributing-packages/#wheels
 universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,7 @@ license_file = LICENSE.txt
 # This flag says to generate wheels that support both Python 2 and Python
 # 3. If your code will not run unchanged on both Python 2 and 3, you will
 # need to generate separate wheels for each Python version that you
-# support. Setting the value of 'universal' to anything other than '1',
-# 'true' or 'yes' (case insensitive) or removing this line will prevent
+# support. Removing this line (or setting universal to 0) will prevent
 # bdist_wheel from trying to make a universal wheel. For more see:
 # https://packaging.python.org/tutorials/distributing-packages/#wheels
 universal=1


### PR DESCRIPTION
When I first encountered the original comment I found it a bit vague because I didn't really know about wheels. I knew that the package I wanted to make wouldn't work on Python 2 so I didn't want to make a universal wheel. But I had to research how this line needed to be changed to do what I wanted, and ended up reading the bdist_wheel.py source to find the answer, which seems excessively difficult. These changes hopefully make it more obvious what to do in my situation.