### PR TITLE
Handle Windows line endings correctly in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,12 @@ https://github.com/pypa/sampleproject
 
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-# To use a consistent encoding
-from codecs import open
 from os import path
+# io.open is needed for projects that support Python 2.7
+# It ensures open() defaults to text mode with universal newlines,
+# and accepts an argument to specify the text encoding
+# Python 3 only projects can skip this import
+from io import open
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
codecs.open doesn't implement universal newlines handling, which
causes metadata parsing problems if the `README` file uses
Windows line endings.

Switching to io.open instead gives the Python 3 open()
semantics (the main reason to prefer codecs.open()
instead was for Python 2.5 support, which is no longer
a concern)

Prompted by https://github.com/pypa/packaging-problems/issues/160