### PR TITLE
Clarify usage of readme_renderer in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,10 @@
 #
 #  - check-manifest
 #     confirm items checked into vcs are in your sdist
-#  - python setup.py check (using the readme_renderer extension)
-#     confirms your long_description will render correctly on pypi
+#  - python setup.py check 
+#     confirm required package meta-data in setup.py
+#  - readme_renderer (when using a ReStructuredText README)
+#     confirms your long_description will render correctly on PyPI.
 #
 #  and also to help confirm pull requests to this project.
 
@@ -21,11 +23,15 @@ basepython =
     py36: python3.6
 deps =
     check-manifest
-    readme_renderer
+    # If your project uses README.rst, uncomment the following: 
+    # readme_renderer
     flake8
     pytest
 commands =
     check-manifest --ignore tox.ini,tests*
+    # This repository uses a Markdown long_description, so the -r flag to
+    # `setup.py check` is not needed. If your project contains a README.rst,
+    # use `python setup.py check -m -r -s` instead.
     python setup.py check -m -s
     flake8 .
     py.test tests


### PR DESCRIPTION
When the sampleproject README was converted from .rst to .md, some of
the explanatory text was no longer valid.
See 1fd9d2ad4dc8c99d8d492740eaf3f1ce8ba9daa5.