### PR TITLE
Make description optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary
-    description='A sample Python project',  # Required
+    description='A sample Python project',  # Optional
 
     # This is an optional longer description of your project that represents
     # the body of text which users will see when they visit PyPI.


### PR DESCRIPTION
`description` keyword corresponds to "Summary" metadata field. "Summary" is not
a required field as described below:

https://packaging.python.org/specifications/core-metadata/
> `Metadata-Version`
> `Name`
> `Version`
> All the other fields are optional.