### PR TITLE
Fix link to PyPUG section on building wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,5 @@ license_file = LICENSE.txt
 # need to generate separate wheels for each Python version that you
 # support. Removing this line (or setting universal to 0) will prevent
 # bdist_wheel from trying to make a universal wheel. For more see:
-# https://packaging.python.org/tutorials/distributing-packages/#wheels
+# https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
 universal=1


### PR DESCRIPTION
The current link in `setup.cfg` redirects to https://packaging.python.org/tutorials/packaging-projects/#wheels, which has no information on wheels.