### PR TITLE
Update setup.cfg (#85)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-# This includes the license(s) file(s) in the wheel.
+# This includes the license file(s) in the wheel.
 # https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
 license_files = LICENSE.txt
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
-# This includes the license file in the wheel.
-license_file = LICENSE.txt
+# This includes the license(s) file(s) in the wheel.
+# https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
+license_files = LICENSE.txt
 
 [bdist_wheel]
 # This flag says to generate wheels that support both Python 2 and Python


### PR DESCRIPTION
Fix #85

Replaces deprecated "license_file" with the more versatile "license_files".

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file