### PR TITLE
Add pyproject toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include pyproject.toml
+
 # Include the README
 include *.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 41.4", "wheel >= 0.33.6"]
+build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,6 @@
 envlist = py{27,35,36,37,38}
 
 [testenv]
-basepython =
-    py27: python2.7
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
-    py38: python3.8
 deps =
     check-manifest
     # If your project uses README.rst, uncomment the following:

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@
 
 [tox]
 envlist = py{27,35,36,37,38}
+isolated_build = True
 
 [testenv]
 deps =


### PR DESCRIPTION
Closes #79 

This is a version of this that I think is less controversial than #101, as it does not pin to a specific version of `setuptools` or `wheel`.

The basepython declarations need to be removed in order to enable build isolation in `tox` for some reason. When I have time I can dig into that and see if it's a bug in `tox`.