### PR TITLE
Update check-manifest invocation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
     flake8
     pytest
 commands =
-    check-manifest --ignore tox.ini,tests*
+    check-manifest --ignore 'tox.ini,tests,tests/**'
     # This repository uses a Markdown long_description, so the -r flag to
     # `setup.py check` is not needed. If your project contains a README.rst,
     # use `python setup.py check -m -r -s` instead.


### PR DESCRIPTION
check-manifest 0.42 updated `--ignore` handling to be more consistent with MANIFEST.in `global-exclude` directives.  As a result, `tests*` no longer matches files inside a `tests` directory, and you have to use `tests/**` instead.

As an extra complication, check-manifest 0.42 drops Python 2.7 support.  Since you still have py27 in this tox.ini, this means you get an older check-manifest 0.41, and you have to tell it to ignore the empty `tests` directory that remains after you exclude all the files in it.

For all the gory details see the second half of https://github.com/mgedmin/check-manifest/issues/98.

I apologize for the inconvenience!