### PR TITLE
Update sample author email

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,11 +65,11 @@ setup(
 
     # This should be your name or the name of the organization which owns the
     # project.
-    author='The Python Packaging Authority',  # Optional
+    author='A. Random Developer',  # Optional
 
     # This should be a valid email address corresponding to the author listed
     # above.
-    author_email='pypa-dev@googlegroups.com',  # Optional
+    author_email='author@example.com',  # Optional
 
     # Classifiers help users find your project by categorizing it.
     #


### PR DESCRIPTION
Per https://groups.google.com/d/msg/pypa-dev/rUNsfIbruHM/LCEx-CB5AgAJ
the pypa-dev Google Group is now decommissioned.
Pointing to distutils-sig instead for the sample
author email address.

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>