### PR TITLE
106 add commas to keywords in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,8 +112,9 @@ setup(
     # This field adds keywords for your project which will appear on the
     # project page. What does your project relate to?
     #
-    # Note that this is a string of words separated by a comma and single
-    # whitespace, not a list.
+    # Note that this is a A list of additional keywords, separated
+    # by commas, to be used to assist searching for the distribution in a
+    # larger catalog.
     keywords='sample, setuptools, development',  # Optional
 
     # When your source code is in a subdirectory under the project root, e.g.

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
     # project page. What does your project relate to?
     #
     # Note that this is a string of words separated by whitespace, not a list.
-    keywords='sample setuptools development',  # Optional
+    keywords='sample, setuptools, development',  # Optional
 
     # When your source code is in a subdirectory under the project root, e.g.
     # `src/`, it is necessary to specify the `package_dir` argument.

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
     # This field adds keywords for your project which will appear on the
     # project page. What does your project relate to?
     #
-    # Note that this is a string of words separated by whitespace, not a list.
+    # Note that this is a string of words separated by a comma and single whitespace, not a list.
     keywords='sample, setuptools, development',  # Optional
 
     # When your source code is in a subdirectory under the project root, e.g.

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,8 @@ setup(
     # This field adds keywords for your project which will appear on the
     # project page. What does your project relate to?
     #
-    # Note that this is a string of words separated by a comma and single whitespace, not a list.
+    # Note that this is a string of words separated by a comma and single
+    # whitespace, not a list.
     keywords='sample, setuptools, development',  # Optional
 
     # When your source code is in a subdirectory under the project root, e.g.

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
     # This field adds keywords for your project which will appear on the
     # project page. What does your project relate to?
     #
-    # Note that this is a A list of additional keywords, separated
+    # Note that this is a list of additional keywords, separated
     # by commas, to be used to assist searching for the distribution in a
     # larger catalog.
     keywords='sample, setuptools, development',  # Optional


### PR DESCRIPTION
Per ticket comments, added commas (with spaces) to keywords in setup.py.

Fixes #106.