### PR TITLE
Update URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     #
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
+    # https://packaging.python.org/guides/single-sourcing-package-version/
     version='2.0.0',  # Required
 
     # This is a one-line description or tagline of what your project does. This


### PR DESCRIPTION
The discussion on single-sourcing the version across setup.py and the project code is to be found at https://packaging.python.org/guides/single-sourcing-package-version/ now.