### PR TITLE
Remove MANIFEST.in entirely

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,2 @@
-# Include the README
-include *.md
-
 # Include the data files
 recursive-include data *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-# Include the data files
-recursive-include data *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,5 @@
-include pyproject.toml
-
 # Include the README
 include *.md
-
-# Include the license file
-include LICENSE.txt
-
-# Include setup.py
-include setup.py
 
 # Include the data files
 recursive-include data *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=40.8.0", "wheel"]
+requires = ["setuptools>=43.0.0", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Closes #152. According to https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist, all the files described in our manifest are now included by `setuptools` (`>=43.0.0`), so the manifest is now redundant.

Tell me if I have to do something else.

cc @di