### PR TITLE
Brush up github release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install build dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,6 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.pypi_password }}
+        username: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
         skip_existing: true


### PR DESCRIPTION
mainly it adds the parameter `username` which is required for the action to work.
also it switches to the recommended pypi token.