### PR TITLE
Remove mention of deprecated setuptools features

### DIFF
--- a/data/data_file
+++ b/data/data_file
@@ -1,1 +1,0 @@
-some data

--- a/setup.py
+++ b/setup.py
@@ -145,18 +145,7 @@ setup(
     package_data={  # Optional
         "sample": ["package_data.dat"],
     },
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages. See:
-    # http://docs.python.org/distutils/setupscript.html#installing-additional-files
-    #
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[("my_data", ["data/data_file"])],  # Optional
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # `pip` to create the appropriate form of executable for the target
-    # platform.
-    #
-    # For example, the following would provide a command called `sample` which
+    # Entry points. The following would provide a command called `sample` which
     # executes the function `main` from this package when invoked:
     entry_points={  # Optional
         "console_scripts": [

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,6 @@ deps =
     pytest
 commands =
     check-manifest --ignore 'tox.ini,tests/**'
-    # This repository uses a Markdown long_description, so the -r flag to
-    # `setup.py check` is not needed. If your project contains a README.rst,
-    # use `python setup.py check -m -r -s` instead.
     flake8 .
     py.test tests {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,6 @@
 #
 #  - check-manifest
 #     confirm items checked into vcs are in your sdist
-#  - python setup.py check
-#     confirm required package meta-data in setup.py
 #  - readme_renderer (when using a ReStructuredText README)
 #     confirms your long_description will render correctly on PyPI.
 #
@@ -38,7 +36,6 @@ commands =
     # This repository uses a Markdown long_description, so the -r flag to
     # `setup.py check` is not needed. If your project contains a README.rst,
     # use `python setup.py check -m -r -s` instead.
-    python setup.py check -m -s
     flake8 .
     py.test tests {posargs}
 


### PR DESCRIPTION
Removes mention of
* data_files (package data is recommended)
* scripts (entry points are recommended)
* `setup.py check` (direct invocation of `setup.py` is deprecated)