### PR TITLE
Remove workflow warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install build dependencies


### PR DESCRIPTION
I noticed the warnings during my packaging experiments.
This change is how I got rid of them, see https://github.com/Daemo00/packaging_tutorial/compare/3.0.3...3.0.4.

The warnings are in the workflow page of https://github.com/Daemo00/packaging_tutorial/tree/3.0.3: 
![image](https://user-images.githubusercontent.com/23295253/234350451-75a7df0d-f2d1-4f35-b8f9-45349bc89f82.png)
(from https://github.com/Daemo00/packaging_tutorial/actions/runs/4799941493)