### PR TITLE
Fix reference to requires-python in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ description = "A sample Python project"  # Optional
 readme = "README.md" # Optional
 
 # Specify which Python versions you support. In contrast to the
-# 'Programming Language' classifiers above, 'pip install' will check this
+# 'Programming Language' classifiers below, 'pip install' will check this
 # and refuse to install the project if the version does not match. See
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
 requires-python = ">=3.7"
@@ -86,7 +86,7 @@ classifiers = [  # Optional
 
   # Specify the Python versions you support here. In particular, ensure
   # that you indicate you support Python 3. These classifiers are *not*
-  # checked by "pip install". See instead "python_requires" below.
+  # checked by "pip install". See instead "requires-python" above.
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
The comment for `classifiers` mistakenly refers to `python_requires` instead of `requires-python`, and above/below is wrong.