### PR TITLE
Update workflow actions to remove warning messages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Install test dependencies


### PR DESCRIPTION
When GitHub Actions runs the `test.yml` workflow file a user warning is raised.  One for each platform version combination in the matrix.

![Screen Shot 2024-06-17 at 6 33 52 PM](https://github.com/pypa/sampleproject/assets/720060/aab35fc9-825f-4b9d-89cf-b2ea326b481b)

Updating the `checkout` action and `setup-python` action resolve the issue.

- `Checkout`: https://github.com/marketplace/actions/checkout
- `setup-python`: https://github.com/marketplace/actions/setup-python