### PR TITLE
pyproject: prep 4.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,8 +10,9 @@
 #
 #  and also to help confirm pull requests to this project.
 
-import nox
 import os
+
+import nox
 
 nox.options.sessions = ["lint"]
 
@@ -39,7 +40,7 @@ def build_and_check_dists(session):
     session.run("python", "-m", "twine", "check", "dist/*")
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 def tests(session):
     session.install("pytest")
     build_and_check_dists(session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ name = "sampleproject"  # REQUIRED, is the only field that cannot be marked as d
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "3.0.0"  # REQUIRED, although can be dynamic
+version = "4.0.0"  # REQUIRED, although can be dynamic
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:
@@ -128,7 +128,7 @@ dependencies = [
 #
 #   $ pip install sampleproject[dev]
 #
-# Optional dependencies the project provides. These are commonly 
+# Optional dependencies the project provides. These are commonly
 # referred to as "extras". For a more extensive definition see:
 # https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@
 # https://packaging.python.org/en/latest/tutorials/packaging-projects/#choosing-a-build-backend
 [build-system]
 # A list of packages that are needed to build your package:
-requires = ["setuptools"]  # REQUIRED if [build-system] table is used
+requires = ["setuptools"] # REQUIRED if [build-system] table is used
 # The name of the Python object that frontends will use to perform the build:
-build-backend = "setuptools.build_meta"  # If not defined, then legacy behavior can happen.
+build-backend = "setuptools.build_meta" # If not defined, then legacy behavior can happen.
 
 
 [project]
@@ -26,14 +26,14 @@ build-backend = "setuptools.build_meta"  # If not defined, then legacy behavior 
 # There are some restrictions on what makes a valid project name
 # specification here:
 # https://packaging.python.org/specifications/core-metadata/#name
-name = "sampleproject"  # REQUIRED, is the only field that cannot be marked as dynamic.
+name = "sampleproject" # REQUIRED, is the only field that cannot be marked as dynamic.
 
 # Versions should comply with PEP 440:
 # https://www.python.org/dev/peps/pep-0440/
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "4.0.0"  # REQUIRED, although can be dynamic
+version = "4.0.0" # REQUIRED, although can be dynamic
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:
@@ -54,12 +54,12 @@ readme = "README.md"
 # 'Programming Language' classifiers in this file, 'pip install' will check this
 # and refuse to install the project if the version does not match. See
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 # This is either text indicating the license for the distribution, or a file
 # that contains the license.
 # https://packaging.python.org/en/latest/specifications/core-metadata/#license
-license = {file = "LICENSE.txt"}
+license = { file = "LICENSE.txt" }
 
 # This field adds keywords for your project which will appear on the
 # project page. What does your project relate to?
@@ -72,15 +72,13 @@ keywords = ["sample", "setuptools", "development"]
 # This should be your name or the name of the organization who originally
 # authored the project, and a valid email address corresponding to the name
 # listed.
-authors = [
-  {name = "A. Random Developer", email = "author@example.com" }
-]
+authors = [{ name = "A. Random Developer", email = "author@example.com" }]
 
 # This should be your name or the names of the organization who currently
 # maintains the project, and a valid email address corresponding to the name
 # listed.
 maintainers = [
-  {name = "A. Great Maintainer", email = "maintainer@example.com" }
+  { name = "A. Great Maintainer", email = "maintainer@example.com" },
 ]
 
 # Classifiers help users find your project by categorizing it.
@@ -104,11 +102,11 @@ classifiers = [
   # that you indicate you support Python 3. These classifiers are *not*
   # checked by "pip install". See instead "requires-python" key in this file.
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
 ]
 
@@ -118,9 +116,7 @@ classifiers = [
 #
 # For an analysis of this field vs pip's requirements files see:
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
-dependencies = [
-  "peppercorn"
-]
+dependencies = ["peppercorn"]
 
 # List additional groups of dependencies here (e.g. development
 # dependencies). Users will be able to install these using the "extras"
@@ -163,4 +159,4 @@ sample = "sample:main"
 [tool.setuptools]
 # If there are data files included in your packages that need to be
 # installed, specify them here.
-package-data = {"sample" = ["*.dat"]}
+package-data = { "sample" = ["*.dat"] }


### PR DESCRIPTION
Per https://github.com/pypi/warehouse/pull/16398, it'd be good to do a release of `sampleproject` with the Trusted Publisher that's already configured, since it'll now generate an attestation that can be used in PyPI's user-facing documentation 🙂 

CC @di for viz

(P.S. please let me know if there's anything else I need to do to prep a release here -- I couldn't find much else!)