### PR TITLE
chore: fixup nox, license metadata

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -17,15 +17,14 @@ import nox
 nox.options.sessions = ["lint"]
 
 # Define the minimal nox version required to run
-nox.options.needs_version = ">= 2024.3.2"
+nox.needs_version = ">= 2024.3.2"
 
 
 @nox.session
 def lint(session):
     session.install("flake8")
     session.run(
-        "flake8", "--exclude", ".nox,*.egg,build,data",
-        "--select", "E,W,F", "."
+        "flake8", "--exclude", ".nox,*.egg,build,data", "--select", "E,W,F", "."
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,8 @@ nox.needs_version = ">= 2024.3.2"
 def lint(session):
     session.install("flake8")
     session.run(
-        "flake8", "--exclude", ".nox,*.egg,build,data", "--select", "E,W,F", "."
+        "flake8", "--exclude", ".nox,*.egg,build,data",
+        "--select", "E,W,F", "."
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ name = "sampleproject" # REQUIRED, is the only field that cannot be marked as dy
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "4.0.0" # REQUIRED, although can be dynamic
+version = "4.0.1" # REQUIRED, although can be dynamic
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:
@@ -59,7 +59,8 @@ requires-python = ">=3.9"
 # This is either text indicating the license for the distribution, or a file
 # that contains the license.
 # https://packaging.python.org/en/latest/specifications/core-metadata/#license
-license = { file = "LICENSE.txt" }
+license-files = ["LICENSE.txt"]
+license = "MIT"
 
 # This field adds keywords for your project which will appear on the
 # project page. What does your project relate to?
@@ -94,9 +95,6 @@ classifiers = [
   # Indicate who your project is intended for
   "Intended Audience :: Developers",
   "Topic :: Software Development :: Build Tools",
-
-  # Pick your license as you wish
-  "License :: OSI Approved :: MIT License",
 
   # Specify the Python versions you support here. In particular, ensure
   # that you indicate you support Python 3. These classifiers are *not*


### PR DESCRIPTION
This performs a set of small fixups to `sampleproject`:

* `nox.options.needs_version` is apparently (now?) `nox.needs_version`
* `setuptools` now wants PEP 639-style metadata, so I've turned `license` from an array of tables into a separate `license` and `license-files` pair.
* `setuptools` appears to be discouraging license classifiers in favor of the former.