### PR TITLE
Restrict OIDC token to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,10 @@ on:
       - main
 
 jobs:
-  build-and-publish:
+  build:
     runs-on: ubuntu-latest
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -25,6 +24,25 @@ jobs:
       run: python -m pip install -U setuptools wheel build
     - name: Build
       run: python -m build .
+    - name: Upload artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: dist
+        path: dist/*
+        if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      with:
+        name: dist
+        path: dist
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
The GH OIDC token used for Trusted Publishing should not be available to non-publishing steps. This PR removes it from the steps that install the dependencies and build the project, so that it's only available during PyPI publishing.

cc @miketheman